### PR TITLE
edit.README.md（DB設計）

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false,foreign_key: true|
 ### Association
-- belongs_to :group
-- belongs_to :user
+- belongs_to :groups
+- belongs_to :users
 
 ## usersテーブル
 |Column|Type|Options|
@@ -57,7 +57,7 @@ Things you may want to cover:
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
+|users_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :groups

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Things you may want to cover:
 |user_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false,foreign_key: true|
 ### Association
-- belongs_to :groups
-- belongs_to :users
+- belongs_to :group
+- belongs_to :user
 
 ## usersテーブル
 |Column|Type|Options|
@@ -60,6 +60,6 @@ Things you may want to cover:
 |users_id|integer|null: false, foreign_key: true|
 |groups_id|integer|null: false, foreign_key: true|
 ### Association
-- belongs_to :groups
-- belongs_to :users
+- belongs_to :group
+- belongs_to :user
 


### PR DESCRIPTION
#What
chat-spaceのDB設計をおこないました。
messagesテーブル
usersテーブル
groupsテーブル
groups_usersテーブル
各カラム空の値が入ってはいけないuser_idやgroup_idにはNOTNUL制約を設定し、emailアドレスには一意性制約を設定しました。
あるユーザーは複数のグループに所属する。あるグループには複数ユーザーが所属する。この関係性はgroups_usersテーブル


#Why
chat-spaceの各機能を想定する際に必須の為。
